### PR TITLE
added error page for email verification

### DIFF
--- a/src/app/(auth)/auth/confirm/route.ts
+++ b/src/app/(auth)/auth/confirm/route.ts
@@ -29,6 +29,6 @@ export async function GET(request: NextRequest) {
     }
 
     // return the user to an error page with some instructions
-    redirectTo.pathname = "/error";
+    redirectTo.pathname = "/signup/verify-email/error";
     return NextResponse.redirect(redirectTo);
 }

--- a/src/app/(auth)/signup/verify-email/error/page.tsx
+++ b/src/app/(auth)/signup/verify-email/error/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import React from "react";
+
+export default function SignUpErrorPage() {
+    return (
+        <div className="w-fit h-fit flex flex-col items-center gap-4">
+            <h1 className="text-xl font-bold">Uh oh!</h1>
+            <div className="flex flex-col items-center justify-center">
+                <h2 className="text-lg">
+                    Looks like there was an error verifying your email.
+                </h2>
+                <h2 className="text-lg">
+                    Please&nbsp;
+                    <Link className="text-blue-500 text-lg" href="signin">
+                        sign in
+                    </Link>
+                    &nbsp;so we can try to verify your email again.
+                </h2>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Added an error page for email verification. Accessible at `/signup/verify-email/error`. Will be redirected to this page when an email verification errors out. It will prompt the user to sign in again after which they will either be signed in if the email verification had succesded and errored out for no reason or it will send another verification email allowing the user to verify it again.