### PR TITLE
clarify parody

### DIFF
--- a/src/app/(dashboard)/submit-info/page.tsx
+++ b/src/app/(dashboard)/submit-info/page.tsx
@@ -61,7 +61,7 @@ export default function SubmitInfo() {
                     </div>
                     <div className="w-full md:w-1/2">
                         <h2 className="text-4xl font-semibold pb-4">Review</h2>
-                        <span>Submissions using trademarks like "CWRU" must have recognizable parody/humor. After review, approved submissions go to the design board!</span>
+                        <span>Submissions using trademarks like &quot;CWRU&quot; must have recognizable parody/humor. After review, approved submissions go to the design board!</span>
                     </div>
                 </div>
 


### PR DESCRIPTION
quick pr to make it more clear how submitted designs must have clear parody.